### PR TITLE
Some enhancements to slack-rtm-api

### DIFF
--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -3,6 +3,7 @@ require 'net/http'
 require 'socket'
 require 'websocket/driver'
 require 'logger'
+include IO::WaitReadable
 
 module SlackRTMApi
 
@@ -10,9 +11,11 @@ module SlackRTMApi
     VALID_DRIVER_EVENTS = [:open, :message, :error]
     BASE_URL            = 'https://slack.com/api'
     RTM_START_PATH      = '/rtm.start'
+    IO_SELECT_TIMEOUT   = 0.001
 
-    def initialize(token: nil, silent: true)
+    def initialize(token: nil, ping_threshold: 15, silent: true)
       @token      = token
+      @ping_threshold = ping_threshold
       @silent     = silent
 
       @logger     = logger = Logger.new(STDOUT) unless silent
@@ -48,10 +51,11 @@ module SlackRTMApi
       @socket.connect
 
       @driver = WebSocket::Driver.client SlackRTMApi::ClientWrapper.new(@url.to_s, @socket)
+      @last_activity = Time.new.to_i
 
       @driver.on :open do
         @connected = true
-        @last_activity = Time.new
+        @last_activity = Time.new.to_i
         send_log "WebSocket::Driver is now connected"
         @event_handlers[:open].call unless @event_handlers[:open].nil?
       end
@@ -65,14 +69,14 @@ module SlackRTMApi
 
       @driver.on :error do |event|
         @connected = false
-        @last_activity = Time.new
+        @last_activity = Time.new.to_i
         send_log "WebSocket::Driver received an error"
         @event_handlers[:error].call unless @event_handlers[:error].nil?
       end
 
       @driver.on :message do |event|
         data = JSON.parse event.data
-        @last_activity = Time.new
+        @last_activity = Time.new.to_i
         send_log "WebSocket::Driver received an event with data: #{data}"
         if data['type'] == 'reconnect_url'
           @url = data['url']
@@ -89,7 +93,10 @@ module SlackRTMApi
     def start
       t = Thread.new do
         init
-        loop { check_ws }
+        loop do
+          check_ws
+          sleep 0.1
+        end
       end
 
       t.abort_on_exception = true
@@ -98,9 +105,16 @@ module SlackRTMApi
     private
 
     def check_ws
-      data = @socket.readpartial 4096
-      @driver.parse data unless data.nil? || data.empty?
+      if IO.select([@socket], nil, nil, IO_SELECT_TIMEOUT)
+        data = @socket.readpartial 4096
+        @driver.parse data unless data.nil? || data.empty?
+      end
       handle_events_queue
+      tdiff = Time.new.to_i - @last_activity
+      if Time.new.to_i - @last_activity > @ping_threshold
+        @driver.ping
+        @last_activity = Time.new.to_i
+      end
     end
 
     def handle_events_queue

--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -11,7 +11,7 @@ module SlackRTMApi
     BASE_URL            = 'https://slack.com/api'
     RTM_START_PATH      = '/rtm.start'
 
-    def initialize(token: token, silent: true, start: true)
+    def initialize(token: nil, silent: true)
       @token      = token
       @silent     = silent
 
@@ -21,12 +21,10 @@ module SlackRTMApi
       @event_handlers = {}
       @events_queue   = []
 
-      @url = get_ws_url
-
-      unless token
-        raise ArgumentError.new 'You should pass a valid RTM Websocket url'
+      if token
+        @url = get_ws_url
       else
-        start if start
+        raise ArgumentError.new 'SlackRTMApi::ApiClient missing token'
       end
     end
 

--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'net/http'
 require 'socket'
 require 'websocket/driver'
 require 'logger'

--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -27,7 +27,7 @@ module SlackRTMApi
       @ping_threshold = ping_threshold
 
       @logger = logger = Logger.new(STDOUT) if @debug
-      @connection_status = :closed # one of [:closed, :opening, :open]
+      @connection_status = :closed # one of [:closed, :connecting, :initializing, :open]
       @event_handlers = {}
       @events_queue = []
       @thread
@@ -161,7 +161,7 @@ module SlackRTMApi
 
     def register_driver_open
       @driver.on :open do
-        @connection_status = :opening
+        @connection_status = :initializing
         @last_activity = Time.new.to_i
         send_log "WebSocket::Driver :open"
         @event_handlers[:open].call if @event_handlers[:open]

--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -8,98 +8,66 @@ include IO::WaitReadable
 module SlackRTMApi
 
   class ApiClient
-    VALID_DRIVER_EVENTS = [:open, :message, :error]
-    BASE_URL            = 'https://slack.com/api'
-    RTM_START_PATH      = '/rtm.start'
+    VALID_DRIVER_EVENTS = [:open, :close, :message, :error]
+    RTM_API_URL = 'https://slack.com/api/rtm.start'
     IO_SELECT_TIMEOUT   = 0.001
 
-    def initialize(token: nil, ping_threshold: 15, silent: true)
-      @token      = token
-      @ping_threshold = ping_threshold
-      @silent     = silent
+    attr_reader :connection_status
 
-      @logger     = logger = Logger.new(STDOUT) unless silent
-      @connected  = false
-      @ready      = false
+    def initialize(
+      auto_start: true,
+      auto_reconnect: true,
+      debug: false,
+      ping_threshold: 15,
+      token: nil
+    )
+      @auto_reconnect = auto_reconnect
+      @debug = debug
+      @token = token
+      @ping_threshold = ping_threshold
+
+      @logger = logger = Logger.new(STDOUT) if @debug
+      @connection_status = :closed # one of [:closed, :opening, :open]
       @event_handlers = {}
-      @events_queue   = []
+      @events_queue = []
+      @thread
 
       if token
-        @url = get_ws_url
+        @url = get_initial_url
+        start if auto_start
       else
         raise ArgumentError.new 'SlackRTMApi::ApiClient missing token'
       end
     end
 
-    def bind(type, &block)
-      unless VALID_DRIVER_EVENTS.include? type
-        raise ArgumentError.new "The event `#{type}` doesn't exist, available events are: #{VALID_DRIVER_EVENTS}"
+    def bind(event_type: nil, event_handler: nil)
+      unless VALID_DRIVER_EVENTS.include? event_type
+        raise ArgumentError.new "Invalid Event (#{event_type}) valid events are: #{VALID_DRIVER_EVENTS}"
       end
-
-      @event_handlers[type] = block
+      @event_handlers[event_type] = event_handler
     end
 
     def send(event)
-      event[:id] = random_id
+      event[:id] = message_id
       @events_queue << event.to_json
     end
 
-    def init
-      return if @ready
-
-      @socket = OpenSSL::SSL::SSLSocket.new TCPSocket.new(@url.host, 443)
-      @socket.connect
-
-      @driver = WebSocket::Driver.client SlackRTMApi::ClientWrapper.new(@url.to_s, @socket)
-      @last_activity = Time.new.to_i
-
-      @driver.on :open do
-        @connected = true
-        @last_activity = Time.new.to_i
-        send_log "WebSocket::Driver is now connected"
-        @event_handlers[:open].call unless @event_handlers[:open].nil?
-      end
-
-      @driver.on :close do |event|
-        @connected = false
-        send_log "WebSocket::Driver received a close event"
-        @event_handlers[:close].call if @event_handlers[:close]
-        init
-      end
-
-      @driver.on :error do |event|
-        @connected = false
-        @last_activity = Time.new.to_i
-        send_log "WebSocket::Driver received an error"
-        @event_handlers[:error].call unless @event_handlers[:error].nil?
-      end
-
-      @driver.on :message do |event|
-        data = JSON.parse event.data
-        @last_activity = Time.new.to_i
-        send_log "WebSocket::Driver received an event with data: #{data}"
-        if data['type'] == 'reconnect_url'
-          @url = data['url']
-          send_log "SlackRTMApi::ApiClient#@driver.on :message URL Updated #{@url}"
-        else
-          @event_handlers[:message].call data unless @event_handlers[:message].nil?
-        end
-      end
-
-      @driver.start
-      @ready = true
+    def close
+      @connection_status = :closed
+      return unless @thread
+      @thread.kill
+      @thread = nil 
+      @driver.close 
     end
 
     def start
-      t = Thread.new do
-        init
+      @thread = Thread.new do
+        connect_to_slack
         loop do
-          check_ws
-          sleep 0.1
+          check_ws if @connection_status != :closed
         end
       end
-
-      t.abort_on_exception = true
+      @thread.abort_on_exception = true
     end
 
     private
@@ -117,6 +85,17 @@ module SlackRTMApi
       end
     end
 
+    def connect_to_slack
+      return if @connection_status == :open
+      @connection_status = :connecting
+      @socket = OpenSSL::SSL::SSLSocket.new TCPSocket.new(@url.host, 443)
+      @socket.connect
+      @driver = WebSocket::Driver.client SlackRTMApi::ClientWrapper.new(@url.to_s, @socket)
+      register_driver_events
+      @last_activity = Time.now.to_i
+      @driver.start
+    end
+
     def handle_events_queue
       while event = @events_queue.shift
         send_log "WebSocket::Driver send #{event}"
@@ -124,23 +103,73 @@ module SlackRTMApi
       end
     end
 
-    def get_ws_url
-      req   = Net::HTTP.post_form URI(BASE_URL + RTM_START_PATH), token: @token
-      body  = JSON.parse req.body
+    def get_initial_url
+      req = Net::HTTP.post_form URI(RTM_API_URL), token: @token
+      body = JSON.parse req.body
       if body['ok']
         URI body['url']
       else
         raise ArgumentError.new "Slack error: #{body['error']}"
       end
     end
+    
+    def message_id
+      @message_id = 0 unless defined? @message_id
+      @message_id += 1
+    end       
+
+    def register_driver_events 
+      register_driver_open
+      register_driver_close
+      register_driver_error
+      register_driver_message
+    end
+
+    def register_driver_close
+      @driver.on :close do |event|
+        send_log "WebSocket::Driver received a close event"
+        @event_handlers[:close].call if @event_handlers[:close]
+        @connection_status = :closed
+        connect_to_slack if @auto_reconnect
+      end
+    end
+
+    def register_driver_error
+      @driver.on :error do |event|
+        @last_activity = Time.new.to_i
+        send_log "WebSocket::Driver received an error"
+        @event_handlers[:error].call if @event_handlers[:error]
+      end
+    end
+
+    def register_driver_message
+      @driver.on :message do |event|
+        data = JSON.parse event.data
+        @last_activity = Time.new.to_i
+        send_log "WebSocket::Driver received an event with data: #{data}"
+        case data['type']
+        when 'hello'
+          @connection_status = :open
+        when 'reconnect_url'
+          @url = data['url']
+          send_log "SlackRTMApi::ApiClient#@driver.on :message URL Updated #{@url}"
+        else
+          @event_handlers[:message].call data unless @event_handlers[:message].nil?
+        end
+      end
+    end
+
+    def register_driver_open
+      @driver.on :open do
+        @connection_status = :opening
+        @last_activity = Time.new.to_i
+        send_log "WebSocket::Driver :open"
+        @event_handlers[:open].call if @event_handlers[:open]
+      end
+    end
 
     def send_log(log)
-      @logger.info(log) unless @silent
-    end
-
-    def random_id
-      SecureRandom.random_number 9999999
+      @logger.info(log) if @debug
     end
   end
-
 end

--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -11,6 +11,7 @@ module SlackRTMApi
     VALID_DRIVER_EVENTS = [:open, :close, :message, :error]
     RTM_API_URL = 'https://slack.com/api/rtm.start'
 
+    attr_access :auto_reconnect, :debug, :ping_threshhold, :select_timeout, :token
     attr_reader :connection_status
 
     def initialize(

--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -11,7 +11,7 @@ module SlackRTMApi
     VALID_DRIVER_EVENTS = [:open, :close, :message, :error]
     RTM_API_URL = 'https://slack.com/api/rtm.start'
 
-    attr_access :auto_reconnect, :debug, :ping_threshhold, :select_timeout, :token
+    attr_accessor :auto_reconnect, :debug, :ping_threshhold, :select_timeout, :token
     attr_reader :connection_status
 
     def initialize(

--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -55,15 +55,22 @@ module SlackRTMApi
         @event_handlers[:open].call unless @event_handlers[:open].nil?
       end
 
+      @driver.on :close do |event|
+        @connected = false
+        send_log "WebSocket::Driver received a close event"
+        @event_handlers[:close].call if @event_handlers[:close]
+        init
+      end
+
       @driver.on :error do |event|
         @connected = false
-        send_log "WebSocket::Driver recieved an error"
+        send_log "WebSocket::Driver received an error"
         @event_handlers[:error].call unless @event_handlers[:error].nil?
       end
 
       @driver.on :message do |event|
         data = JSON.parse event.data
-        send_log "WebSocket::Driver recieved an event with data: #{data}"
+        send_log "WebSocket::Driver received an event with data: #{data}"
         if data['type'] == 'reconnect_url'
           @url = data['url']
           send_log "SlackRTMApi::ApiClient#@driver.on :message URL Updated #{@url}"
@@ -73,8 +80,11 @@ module SlackRTMApi
       end
 
       @driver.start
-
       @ready = true
+    end
+
+    def init_connection
+
     end
 
     def check_ws


### PR DESCRIPTION
Hi Rémi, I like your slack-rtm-api module, and am planning on using it in a Slack Bot framework I'm working on.  I made some changes to it, if you are interested in merging, check them out.
- Added support for Slack url_reconnects and automatic connection re-establishment
- Added a WebSocket::Driver on :close handler (for automatic connection re-establishment)
- Changed the socket read to not block by using IO::select
- Changed the initialize arguments to use a Hash with symbol keys (I think this is the only not-backwards compatible change)
- I forgot to put this in the git commit, but I added support for WebSocket ping/pong

I'm new to github and pull requests so bear with me if I'm breeching any etiquette or not doing something right.  Thanks,

Rob
