### PR TITLE
Updating docs, fixed bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,14 @@
 
 ## How it works?
 
-1. Initialize a client with `client = SlackRTMApi::ApiClient.new client_token`, where the `client_token` is your client Slack token.
+1. Initialize a client with `client = SlackRTMApi::ApiClient.new(token: client_token)`, where the `client_token` is your client Slack token.
 
 2. Bind websocket events and give them a callback.
-
-3. Use `client.start`, this will start a new Thread, initialize the websocket, fetch for new events and call apropriates bindings
 
 ## How to use?
 
 ```rb
-client = SlackRTMApi::ApiClient.new client_token
+client = SlackRTMApi::ApiClient.new(token: client_token)
 
 client.bind :message do |data|
   if data['type'] == 'message' && data['subtype'] != 'bot_message'
@@ -29,7 +27,7 @@ client.start
 
 ## Bind events
 
-Available events are `open`, `message` and `error`, they all can be binded with the `client.bind` function like this:
+Available events are `open`, `close`, `message` and `error`, they all can be bound with the `client.bind` function like this:
 
 ```rb
 client.bind :open do
@@ -51,12 +49,36 @@ end
 
 ## Options
 
-#### Silenced mode
+#### Debug logging
 
-By default, the gem will log every connexion and events, you can remove those logs by passing `false` as a second argument in the `SlackRTMApi::ApiClient.new` function.
+By default, the gem is silent, however debugging output can be enabled using the `debug: true` option when declaring a new instance, which enables logging to STDOUT via Logger.
 
 ```rb
-client = SlackRTMApi::ApiClient.new client_token, false
-# client = SlackRTMApi::ApiClient.new client_token, Rails.env.production?
+client = SlackRTMApi::ApiClient.new(token: client_token, debug: true)
+```
 
+#### Auto-start mode
+
+By default, declaring a new instance of ApiClient will also initiate the connection to Slack.  If this is not desired behavior, use `auto_start: false` when declaring a new instance.  The timeout before returning if the connection cannot be made is adjustable with the open_wait_timeout options, which defaults to 15 seconds.
+
+```rb
+client = SlackRTMApi::ApiClient.new(token: client_token, auto_start: false)
+# -or-
+client = SlackRTMApi::ApiClient.new(token: client_token, open_wait_timeout: 5)
+```
+
+#### Auto-reconnect mode
+
+SlackRTMApi tracks Slack `reconnect_url` messages, and constantly updates it's internal URL with these periodic messages.  By default, SlackRTMApi will then use the last broadcast URL in order to initiate a reconnect in the case of connection failure.  This behavior can be overidden by using `auto_reconnect: false`
+
+```rb
+client = SlackRTMApi::ApiClient.new(token: client_token, auto_reconnect: false)
+```
+
+#### WebSocket Ping/Pong
+
+SlackRTMApi uses client-initiated [WebSocket Keepalive Ping/Pongs](https://tools.ietf.org/html/rfc6455#section-5.5.2) in order to more quickly realize a broken connection. By default, Ping packets are sent when there is no activity for 15 seconds.  This threshold can be configured by using the `ping_threshold: ##` option.
+
+```rb
+client = SlackRTMApi::ApiClient.new(token: client_token, ping_threshold: 600)
 ```

--- a/lib/slack-rtm-api/api_client.rb
+++ b/lib/slack-rtm-api/api_client.rb
@@ -11,7 +11,7 @@ module SlackRTMApi
     VALID_DRIVER_EVENTS = [:open, :close, :message, :error]
     RTM_API_URL = 'https://slack.com/api/rtm.start'
 
-    attr_accessor :auto_reconnect, :debug, :ping_threshhold, :select_timeout, :token
+    attr_accessor :auto_reconnect, :debug, :ping_threshold, :select_timeout, :token
     attr_reader :connection_status
 
     def initialize(


### PR DESCRIPTION
Updated the README to reflect the new usage.  Also fixed a type-o in ping_threshold used for adjusting WebSocket keepalive timeouts.

Also if you do publish these changes to your gem, keep in mind that the new syntax on ApiClient#intialize is not backwards compatible.
